### PR TITLE
When running as a daemon, always restart

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,2 @@
+#!/bin/sh
+snapctl restart $SNAP_NAME

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,7 +42,7 @@ apps:
   daemon:
     command: run-daemon wayland-launch neverputt
     daemon: simple
-    restart-condition: on-failure
+    restart-condition: always
     environment:
       # Prep PulseAudio
       PULSE_SYSTEM: 1


### PR DESCRIPTION
When running as a daemon, always restart

Made possible by the recent update to mir-kiosk-snap-launch
