### PR TITLE
simplify snap recipe

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,8 +21,6 @@ environment:
 layout:
   /usr/share:
     bind: $SNAP/usr/share
-  /etc/fonts:
-    bind: $SNAP/etc/fonts
   /usr/games:
     bind: $SNAP/usr/games
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,12 +10,7 @@ license: GPL-2.0
 environment:
   SHELL: bash
   LC_ALL: C.UTF-8
-  LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}:${SNAP}/usr/lib/:${SNAP}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/:${SNAP}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/pulseaudio
-  PATH: $SNAP/bin/:$SNAP/usr/bin/:${SNAP}/usr/games:${PATH}
-  # XDG config
-  XDG_CACHE_HOME:  $SNAP_USER_COMMON/.cache
-  XDG_CONFIG_DIRS: ${SNAP}/etc/xdg:$XDG_CONFIG_DIRS
-  XDG_CONFIG_HOME: $SNAP_USER_DATA/.config
+  LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}:${SNAP}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/pulseaudio
   # Prep EGL
   __EGL_VENDOR_LIBRARY_DIRS: $SNAP/etc/glvnd/egl_vendor.d:$SNAP/usr/share/glvnd/egl_vendor.d
   LIBGL_DRIVERS_PATH: ${SNAP}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,8 +8,7 @@ base: core18
 license: GPL-2.0
 
 environment:
-  SHELL: bash
-  LC_ALL: C.UTF-8
+  # ${SNAPCRAFT_ARCH_TRIPLET} doesn't play nice with layout
   LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}:${SNAP}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/pulseaudio
   # Prep EGL
   __EGL_VENDOR_LIBRARY_DIRS: $SNAP/etc/glvnd/egl_vendor.d:$SNAP/usr/share/glvnd/egl_vendor.d


### PR DESCRIPTION
simplify snap recipe: delete stuff that is not needed.

This stuff comes from cut & paste of recipes written long ago and might once have been needed.