### PR TITLE
Consume glvnd info from graphics-core20 interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,6 +15,7 @@ architectures:
 environment:
   LD_LIBRARY_PATH:    $SNAP/graphics/lib
   LIBGL_DRIVERS_PATH: $SNAP/graphics/dri
+  __EGL_VENDOR_LIBRARY_DIRS: $SNAP/graphics/glvnd/egl_vendor.d
   # Prep SDL
   SDL_VIDEODRIVER: wayland
 


### PR DESCRIPTION
For using the mesa libEGL.so.1 we also need the glvnd ICD for mesa.

Already broken on edge, but this fixes it when combined with https://github.com/MirServer/mesa-core20/pull/10